### PR TITLE
chore: use retry template instead of deprecated retry listener and prepare for Gradle 9

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,29 +1,27 @@
 plugins {
-    id "org.springframework.boot" version "3.3.1"
-    id "io.spring.dependency-management" version "1.1.5"
-    id "java"
-    id "jacoco"
-    id "com.diffplug.spotless" version "6.25.0"
+    id 'org.springframework.boot' version "3.3.4"
+    id 'io.spring.dependency-management' version "1.1.6"
+    id 'java'
+    id 'jacoco'
+    id 'com.diffplug.spotless' version "6.25.0"
 }
 
 group = "org.miracum.etl"
 version = "3.13.2"
-sourceCompatibility = "21"
-targetCompatibility = "21"
 
-configurations {
-  compileOnly {
-    extendsFrom annotationProcessor
+java {
+  toolchain {
+    languageVersion = JavaLanguageVersion.of(21)
   }
+}
+
+repositories {
+    mavenCentral()
 }
 
 ext {
     set("springCloudVersion", "2023.0.2")
     set("hapiVersion", "7.2.1")
-}
-
-repositories {
-    mavenCentral()
 }
 
 dependencies {
@@ -50,8 +48,8 @@ dependencies {
     developmentOnly "org.springframework.boot:spring-boot-devtools"
     runtimeOnly "org.postgresql:postgresql:42.7.3"
     runtimeOnly 'com.h2database:h2:2.2.224'
-    annotationProcessor "org.springframework.boot:spring-boot-configuration-processor"
     testImplementation "org.springframework.boot:spring-boot-starter-test"
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 
 dependencyManagement {
@@ -60,11 +58,8 @@ dependencyManagement {
     }
 }
 
-tasks.named("test") {
+tasks.named('test') {
   useJUnitPlatform()
-}
-
-jacoco {
 }
 
 jacocoTestReport {

--- a/build.gradle
+++ b/build.gradle
@@ -31,8 +31,6 @@ dependencies {
     implementation "org.springframework.boot:spring-boot-starter-data-jdbc"
     implementation "org.springframework.boot:spring-boot-starter-web"
 
-    implementation "org.springframework.retry:spring-retry"
-
     implementation "org.springframework.cloud:spring-cloud-stream"
     implementation "org.springframework.cloud:spring-cloud-stream-binder-kafka"
     implementation "org.springframework.kafka:spring-kafka"

--- a/src/main/java/org/miracum/etl/fhirgateway/AppConfig.java
+++ b/src/main/java/org/miracum/etl/fhirgateway/AppConfig.java
@@ -28,8 +28,8 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.retry.RetryCallback;
 import org.springframework.retry.RetryContext;
+import org.springframework.retry.RetryListener;
 import org.springframework.retry.backoff.ExponentialRandomBackOffPolicy;
-import org.springframework.retry.listener.RetryListenerSupport;
 import org.springframework.retry.policy.SimpleRetryPolicy;
 import org.springframework.retry.support.RetryTemplate;
 import org.springframework.web.client.HttpClientErrorException;
@@ -117,7 +117,7 @@ public class AppConfig {
     retryTemplate.setRetryPolicy(new SimpleRetryPolicy(maxAttempts, retryableExceptions));
 
     retryTemplate.registerListener(
-        new RetryListenerSupport() {
+        new RetryListener() {
           @Override
           public <T, E extends Throwable> void onError(
               RetryContext context, RetryCallback<T, E> callback, Throwable throwable) {
@@ -147,7 +147,7 @@ public class AppConfig {
     retryTemplate.setRetryPolicy(new SimpleRetryPolicy(maxAttempts));
 
     retryTemplate.registerListener(
-        new RetryListenerSupport() {
+        new RetryListener() {
           @Override
           public <T, E extends Throwable> void onError(
               RetryContext context, RetryCallback<T, E> callback, Throwable throwable) {

--- a/src/main/java/org/miracum/etl/fhirgateway/stores/FhirServerResourceRepository.java
+++ b/src/main/java/org/miracum/etl/fhirgateway/stores/FhirServerResourceRepository.java
@@ -11,8 +11,8 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.retry.RetryCallback;
 import org.springframework.retry.RetryContext;
+import org.springframework.retry.RetryListener;
 import org.springframework.retry.backoff.FixedBackOffPolicy;
-import org.springframework.retry.listener.RetryListenerSupport;
 import org.springframework.retry.policy.SimpleRetryPolicy;
 import org.springframework.retry.support.RetryTemplate;
 import org.springframework.stereotype.Component;
@@ -42,7 +42,7 @@ public class FhirServerResourceRepository implements FhirResourceRepository {
     retryTemplate.setBackOffPolicy(fixedBackOffPolicy);
     retryTemplate.setRetryPolicy(new SimpleRetryPolicy(5));
     this.retryTemplate.registerListener(
-        new RetryListenerSupport() {
+        new RetryListener() {
           @Override
           public <T, E extends Throwable> void onError(
               RetryContext context, RetryCallback<T, E> callback, Throwable throwable) {


### PR DESCRIPTION
https://github.com/miracum/fhir-gateway/actions/runs/11333383919/job/31517418239?pr=173#step:11:2055
zeigt ein "Warning".
Irgendwie eigenartig - bei mir hat jeder erste (!) Build nach einem clean wegen dieser Deprecation gefailt. Jeder nachfolgende build läuft erfolgreich durch.

So oder so, ich hab mal ein paar chores gemacht, die eh bald fällig wären.